### PR TITLE
Remove Airtable references and permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "name": "TrackTern",
   "version": "2.0.1",
   "description": "Save job listings locally with seamless setup and smart extraction.",
-  "permissions": ["activeTab", "scripting", "storage", "tabs"],
-  "host_permissions": ["https://api.airtable.com/*", "https://airtable.com/*"],
+  "permissions": ["activeTab", "scripting", "storage"],
+  "host_permissions": [],
   "action": {
     "default_popup": "popup.html",
     "default_title": "TrackTern"


### PR DESCRIPTION
Remove unused 'tabs' permission and Airtable host permissions to comply with Chrome Web Store review.

---

[Open in Web](https://cursor.com/agents?id=bc-a36cdb2d-fc8e-43bd-a3cc-905bccd36ac5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a36cdb2d-fc8e-43bd-a3cc-905bccd36ac5)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)